### PR TITLE
feat(poc): transcript-driven Maha Mantra chunk scoring + marker-based flow

### DIFF
--- a/api/src/gemini_music_api/data/maha_mantra_timing_markers.v1.json
+++ b/api/src/gemini_music_api/data/maha_mantra_timing_markers.v1.json
@@ -1,0 +1,81 @@
+{
+  "track_id": "maha_mantra_lZXeUhUc8PM_v1",
+  "source": "transcript_manual_v1",
+  "video_id": "lZXeUhUc8PM",
+  "listen_stage": {
+    "start_sec": 18,
+    "end_sec": 48,
+    "duration_sec": 30
+  },
+  "guided_stage": {
+    "start_sec": 48,
+    "end_sec": 93,
+    "duration_sec": 45
+  },
+  "call_response_stage": {
+    "start_sec": 138,
+    "end_sec": 186,
+    "duration_sec": 48,
+    "rounds": [
+      {
+        "round": 1,
+        "guru_start": 138,
+        "guru_end": 141,
+        "student_start": 141,
+        "student_end": 144
+      },
+      {
+        "round": 2,
+        "guru_start": 144,
+        "guru_end": 147,
+        "student_start": 147,
+        "student_end": 150
+      },
+      {
+        "round": 3,
+        "guru_start": 150,
+        "guru_end": 153,
+        "student_start": 153,
+        "student_end": 156
+      },
+      {
+        "round": 4,
+        "guru_start": 156,
+        "guru_end": 159,
+        "student_start": 159,
+        "student_end": 162
+      },
+      {
+        "round": 5,
+        "guru_start": 162,
+        "guru_end": 165,
+        "student_start": 165,
+        "student_end": 168
+      },
+      {
+        "round": 6,
+        "guru_start": 168,
+        "guru_end": 171,
+        "student_start": 171,
+        "student_end": 174
+      },
+      {
+        "round": 7,
+        "guru_start": 174,
+        "guru_end": 177,
+        "student_start": 177,
+        "student_end": 180
+      },
+      {
+        "round": 8,
+        "guru_start": 180,
+        "guru_end": 183,
+        "student_start": 183,
+        "student_end": 186
+      }
+    ]
+  },
+  "independent_stage": {
+    "duration_sec": 30
+  }
+}

--- a/api/src/gemini_music_api/models.py
+++ b/api/src/gemini_music_api/models.py
@@ -118,6 +118,61 @@ class BhavEvaluation(Base):
     created_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, nullable=False)
 
 
+class AudioChunk(Base):
+    __tablename__ = "audio_chunks"
+    __table_args__ = (
+        UniqueConstraint("session_id", "chunk_id", name="uq_audio_chunk_session_chunk"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String(36), ForeignKey("sessions.id"), nullable=False, index=True)
+    stage: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    round_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chunk_id: Mapped[str] = mapped_column(String(120), nullable=False)
+    seq: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    t_start_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    t_end_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    sample_rate_hz: Mapped[int] = mapped_column(Integer, nullable=False, default=16000)
+    encoding: Mapped[str] = mapped_column(String(40), nullable=False, default="browser_metrics_v1")
+    blob_uri: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    lineage_id: Mapped[str] = mapped_column(String(60), nullable=False, default="vaishnavism")
+    golden_profile: Mapped[str] = mapped_column(String(40), nullable=False, default="maha_mantra_v1")
+    features_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    metrics_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    ingested_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, nullable=False)
+
+
+class StageScoreProjection(Base):
+    __tablename__ = "stage_score_projections"
+    __table_args__ = (
+        UniqueConstraint(
+            "session_id",
+            "stage",
+            "lineage_id",
+            "golden_profile",
+            name="uq_stage_score_projection",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String(36), ForeignKey("sessions.id"), nullable=False, index=True)
+    stage: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    lineage_id: Mapped[str] = mapped_column(String(60), nullable=False, default="vaishnavism", index=True)
+    golden_profile: Mapped[str] = mapped_column(String(40), nullable=False, default="maha_mantra_v1")
+    discipline: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    resonance: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    coherence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    composite: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    passes_golden: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    coverage_ratio: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    source_chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    metrics_json: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+    feedback_json: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, nullable=False)
+
+
 class WebhookSubscription(Base):
     __tablename__ = "webhook_subscriptions"
 

--- a/api/src/gemini_music_api/services/audio_scoring.py
+++ b/api/src/gemini_music_api/services/audio_scoring.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import datetime as dt
+from statistics import mean
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import AudioChunk, StageScoreProjection
+from ..schemas import AudioChunkFeaturesIn, MahaMantraMetrics
+from .bhav import DEFAULT_GOLDEN_PROFILE, resolve_lineage
+from .maha_mantra_eval import STAGE_TARGETS, evaluate_maha_mantra_stage
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def clamp01(value: float | int | None) -> float:
+    if value is None:
+        return 0.0
+    return max(0.0, min(1.0, float(value)))
+
+
+def _weighted_mean(rows: list[tuple[float, float]], default: float) -> float:
+    if not rows:
+        return default
+    total_weight = sum(weight for _, weight in rows)
+    if total_weight <= 0:
+        return default
+    weighted = sum(value * weight for value, weight in rows)
+    return weighted / total_weight
+
+
+def normalize_audio_chunk(
+    *,
+    t_start_ms: int,
+    t_end_ms: int,
+    features: AudioChunkFeaturesIn,
+) -> tuple[dict[str, Any], dict[str, float | None], float]:
+    duration_seconds = float(features.duration_seconds) if features.duration_seconds is not None else (
+        max(0.1, float(t_end_ms - t_start_ms) / 1000.0)
+    )
+    total_frames = int(features.total_frames or 0)
+    voiced_frames = int(features.voiced_frames or 0)
+    if total_frames > 0:
+        voiced_frames = min(voiced_frames, total_frames)
+
+    if features.voice_ratio_total is not None:
+        voice_ratio_total = float(features.voice_ratio_total)
+    elif total_frames > 0:
+        voice_ratio_total = float(voiced_frames) / float(total_frames)
+    else:
+        voice_ratio_total = 0.0
+
+    metrics = {
+        "duration_seconds": round(max(0.1, duration_seconds), 3),
+        "voice_ratio_total": round(clamp01(voice_ratio_total), 3),
+        "voice_ratio_student": (
+            None if features.voice_ratio_student is None else round(clamp01(features.voice_ratio_student), 3)
+        ),
+        "voice_ratio_guru": (
+            None if features.voice_ratio_guru is None else round(clamp01(features.voice_ratio_guru), 3)
+        ),
+        "pitch_stability": round(clamp01(features.pitch_stability if features.pitch_stability is not None else 0.5), 3),
+        "cadence_bpm": round(
+            float(features.cadence_bpm) if features.cadence_bpm is not None else 72.0,
+            2,
+        ),
+        "cadence_consistency": round(
+            clamp01(features.cadence_consistency if features.cadence_consistency is not None else 0.5),
+            3,
+        ),
+        "avg_energy": round(clamp01(features.avg_energy if features.avg_energy is not None else 0.5), 3),
+    }
+
+    snr_db = float(features.snr_db) if features.snr_db is not None else None
+    snr_norm = clamp01((snr_db - 5.0) / 25.0) if snr_db is not None else 0.5
+    signal_quality = mean(
+        [
+            metrics["voice_ratio_total"],
+            metrics["pitch_stability"],
+            metrics["cadence_consistency"],
+        ]
+    )
+    chunk_confidence = round(clamp01((0.6 * signal_quality) + (0.4 * snr_norm)), 3)
+
+    features_json: dict[str, Any] = {
+        "duration_seconds": metrics["duration_seconds"],
+        "total_frames": total_frames,
+        "voiced_frames": voiced_frames,
+        "snr_db": snr_db,
+        "voice_ratio_total": metrics["voice_ratio_total"],
+        "voice_ratio_student": metrics["voice_ratio_student"],
+        "voice_ratio_guru": metrics["voice_ratio_guru"],
+        "pitch_stability": metrics["pitch_stability"],
+        "cadence_bpm": metrics["cadence_bpm"],
+        "cadence_consistency": metrics["cadence_consistency"],
+        "avg_energy": metrics["avg_energy"],
+    }
+    return features_json, metrics, chunk_confidence
+
+
+def _aggregate_stage_metrics(chunks: list[AudioChunk]) -> tuple[MahaMantraMetrics, dict[str, Any]]:
+    if not chunks:
+        raise ValueError("No audio chunks available for aggregation")
+
+    duration_weights: list[float] = []
+    duration_total = 0.0
+    cadence_rows: list[tuple[float, float]] = []
+    pitch_rows: list[tuple[float, float]] = []
+    consistency_rows: list[tuple[float, float]] = []
+    energy_rows: list[tuple[float, float]] = []
+    voice_total_rows: list[tuple[float, float]] = []
+    student_rows: list[tuple[float, float]] = []
+    guru_rows: list[tuple[float, float]] = []
+    snr_values: list[float] = []
+
+    for chunk in chunks:
+        m = chunk.metrics_json or {}
+        f = chunk.features_json or {}
+        duration = max(0.1, float(m.get("duration_seconds") or f.get("duration_seconds") or 0.1))
+        duration_weights.append(duration)
+        duration_total += duration
+
+        cadence_rows.append((float(m.get("cadence_bpm", 72.0)), duration))
+        pitch_rows.append((clamp01(m.get("pitch_stability")), duration))
+        consistency_rows.append((clamp01(m.get("cadence_consistency")), duration))
+        energy_rows.append((clamp01(m.get("avg_energy")), duration))
+        voice_total_rows.append((clamp01(m.get("voice_ratio_total")), duration))
+
+        if m.get("voice_ratio_student") is not None:
+            student_rows.append((clamp01(m.get("voice_ratio_student")), duration))
+        if m.get("voice_ratio_guru") is not None:
+            guru_rows.append((clamp01(m.get("voice_ratio_guru")), duration))
+
+        snr_db = f.get("snr_db")
+        if isinstance(snr_db, (int, float)):
+            snr_values.append(float(snr_db))
+
+    metrics = MahaMantraMetrics(
+        duration_seconds=round(duration_total, 3),
+        voice_ratio_total=round(_weighted_mean(voice_total_rows, 0.0), 3),
+        voice_ratio_student=(
+            round(_weighted_mean(student_rows, 0.0), 3) if student_rows else None
+        ),
+        voice_ratio_guru=round(_weighted_mean(guru_rows, 0.0), 3) if guru_rows else None,
+        pitch_stability=round(_weighted_mean(pitch_rows, 0.5), 3),
+        cadence_bpm=round(_weighted_mean(cadence_rows, 72.0), 2),
+        cadence_consistency=round(_weighted_mean(consistency_rows, 0.5), 3),
+        avg_energy=round(_weighted_mean(energy_rows, 0.5), 3),
+    )
+
+    info = {
+        "duration_total_seconds": round(duration_total, 3),
+        "chunk_count": len(chunks),
+        "snr_mean_db": round(mean(snr_values), 3) if snr_values else None,
+    }
+    return metrics, info
+
+
+def recompute_stage_projection(
+    db: Session,
+    *,
+    session_id: str,
+    stage: str,
+    lineage_id: str,
+    golden_profile: str = DEFAULT_GOLDEN_PROFILE,
+) -> StageScoreProjection:
+    chunks = db.scalars(
+        select(AudioChunk)
+        .where(
+            AudioChunk.session_id == session_id,
+            AudioChunk.stage == stage,
+            AudioChunk.lineage_id == lineage_id,
+            AudioChunk.golden_profile == golden_profile,
+        )
+        .order_by(AudioChunk.seq.asc(), AudioChunk.id.asc())
+    ).all()
+    if not chunks:
+        raise ValueError("No chunks for stage projection")
+
+    metrics, aggregate_info = _aggregate_stage_metrics(chunks)
+    lineage = resolve_lineage(lineage_id)
+    result = evaluate_maha_mantra_stage(
+        stage=stage,
+        metrics=metrics,
+        lineage=lineage,
+        golden_profile=golden_profile,
+    )
+
+    target_duration = float(STAGE_TARGETS[stage]["duration_seconds"])
+    coverage_ratio = clamp01(float(metrics.duration_seconds) / max(1.0, target_duration))
+    snr_mean_db = aggregate_info.get("snr_mean_db")
+    snr_norm = clamp01((float(snr_mean_db) - 5.0) / 25.0) if snr_mean_db is not None else 0.5
+    signal_quality = mean(
+        [
+            clamp01(metrics.voice_ratio_total),
+            clamp01(metrics.pitch_stability),
+            clamp01(metrics.cadence_consistency),
+        ]
+    )
+    confidence = round(clamp01((0.55 * coverage_ratio) + (0.25 * snr_norm) + (0.20 * signal_quality)), 3)
+
+    projection = db.scalars(
+        select(StageScoreProjection).where(
+            StageScoreProjection.session_id == session_id,
+            StageScoreProjection.stage == stage,
+            StageScoreProjection.lineage_id == lineage.id,
+            StageScoreProjection.golden_profile == golden_profile,
+        )
+    ).first()
+    if projection is None:
+        projection = StageScoreProjection(
+            session_id=session_id,
+            stage=stage,
+            lineage_id=lineage.id,
+            golden_profile=golden_profile,
+        )
+        db.add(projection)
+
+    projection.discipline = float(result.discipline)
+    projection.resonance = float(result.resonance)
+    projection.coherence = float(result.coherence)
+    projection.composite = float(result.composite)
+    projection.passes_golden = bool(result.passes_golden)
+    projection.confidence = confidence
+    projection.coverage_ratio = round(coverage_ratio, 3)
+    projection.source_chunk_count = int(aggregate_info["chunk_count"])
+    projection.metrics_json = {
+        **result.metrics_used,
+        "aggregate": aggregate_info,
+    }
+    projection.feedback_json = list(result.feedback)
+    projection.updated_at = _utcnow()
+    db.flush()
+    return projection
+

--- a/api/src/gemini_music_api/services/maha_mantra_eval.py
+++ b/api/src/gemini_music_api/services/maha_mantra_eval.py
@@ -8,7 +8,7 @@ from .bhav import DEFAULT_GOLDEN_PROFILE, LineageProfile, clamp01
 
 STAGE_TARGETS: dict[str, dict[str, float]] = {
     "guided": {"duration_seconds": 45.0, "threshold_offset": -0.08},
-    "call_response": {"duration_seconds": 40.0, "threshold_offset": -0.04},
+    "call_response": {"duration_seconds": 48.0, "threshold_offset": -0.04},
     "independent": {"duration_seconds": 30.0, "threshold_offset": 0.0},
 }
 

--- a/api/src/gemini_music_api/services/maha_mantra_timing.py
+++ b/api/src/gemini_music_api/services/maha_mantra_timing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+TIMING_MARKERS_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "maha_mantra_timing_markers.v1.json"
+)
+
+
+@lru_cache(maxsize=1)
+def load_maha_mantra_timing_markers() -> dict[str, Any]:
+    raw = json.loads(TIMING_MARKERS_PATH.read_text(encoding="utf-8"))
+
+    required_top = {
+        "track_id",
+        "source",
+        "video_id",
+        "listen_stage",
+        "guided_stage",
+        "call_response_stage",
+        "independent_stage",
+    }
+    missing = sorted(required_top - set(raw.keys()))
+    if missing:
+        raise ValueError(f"Missing timing marker fields: {', '.join(missing)}")
+
+    return raw
+

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -62,6 +62,7 @@
       <p class="meta">
         Source track: <a href="https://youtu.be/lZXeUhUc8PM?si=3VsDT1WX6AmZJA2b" target="_blank" rel="noreferrer">Maha Mantra Kirtan on YouTube</a>
       </p>
+      <p id="timingMeta" class="meta">Timing source: loading transcript markers...</p>
     </section>
 
     <!-- Practice Player -->


### PR DESCRIPTION
## Summary
This PR hardens the Maha Mantra POC from fixed client-side timing/scoring into a transcript-driven, server-projected pipeline aligned with DDIA patterns.

### What changed
- Added canonical transcript timing markers artifact:
  - `api/src/gemini_music_api/data/maha_mantra_timing_markers.v1.json`
- Added timing loader service and API:
  - `GET /v1/maha-mantra/timing`
- Added append-only audio chunk ingestion + stage scoring projection models:
  - `audio_chunks`
  - `stage_score_projections`
- Added chunk scoring service:
  - normalizes chunk features
  - aggregates stage metrics
  - recomputes stage projection (`discipline/resonance/coherence/composite`, confidence, coverage)
- Added new APIs:
  - `POST /v1/sessions/{session_id}/audio/chunks`
  - `GET /v1/sessions/{session_id}/stage-projections`
- Updated `/poc` flow to be marker-driven and server-scored:
  - loads timing plan from `/v1/maha-mantra/timing`
  - uses transcript-based stage starts/durations
  - sends stage capture metrics via `/audio/chunks`
  - uses projection response as authoritative stage score
- Updated call-response target duration to transcript-aligned 48s.
- Added tests for timing endpoint and chunk scoring projection.
- Updated API README with new endpoints and flow.

## Why
The prior flow depended on hardcoded stage markers and client-asserted scoring inputs. This change introduces a canonical timing artifact and append-only ingestion/projection split for more trustworthy scoring and better operational traceability.

## Verification
- `cd api && make test`
  - `12 passed`
- `cd api && make demo`
  - passes and writes `api/demo/latest_demo_output.json`
- `/demo` static route smoke test passes via API test suite.

## Notes
- Local secret file `api/.env` remains untracked and is not part of this PR.
